### PR TITLE
Add module support in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "version": "3.0.1",
+  "type": "module",
   "scripts": {
     "astro": "astro",
     "build": "astro build",


### PR DESCRIPTION
Incorporate `"type": "module"` into package.json to enable module support for the project. This change facilitates the use of ES modules throughout the codebase.