### PR TITLE
[#3] CI: Scope staging deployment concurrency group

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@
 name: (staging) Build and Deploy to BunnyCDN
 
 concurrency:
-  group: staging
+  group: ${{ github.workflow }}-staging
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Use the workflow name in the concurrency group to prevent potential conflicts with other workflows that might also use the simple name 'staging'.

Error: Canceling since a deadlock was detected for concurrency group: 'staging' between a top level workflow and 'Deploy Staging'