### PR TITLE
Add Astro sitemap integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Copy this file to .env and replace the values with your actual configuration
 # Note: This file contains sensitive information, DO NOT commit your actual .env file to version control
 
+# Used to set `site` in Astro config (which sitemap relies on as well)
+VITE_BASE_URL=https://example.com
+
 # Activates debug features in dev mode, only is the value is literally "true"
 VITE_DEBUG="true"
 

--- a/config/astro/i18n.ts
+++ b/config/astro/i18n.ts
@@ -42,6 +42,19 @@ export const LANGUAGE_META: {
 };
 
 /**
+ * Flattened locale mapping for i18n configuration
+ */
+export function getLocalesMap(): { [Key in SupportedLanguage]: string } {
+  return Object.entries(LANGUAGE_META).reduce(
+    (acc, [lang, meta]) => ({
+      ...acc,
+      [lang]: meta.locale,
+    }),
+    {} as { [Key in SupportedLanguage]: string },
+  );
+}
+
+/**
  * Astro i18n configuration
  */
 export function createConfig() {

--- a/config/astro/integrations.ts
+++ b/config/astro/integrations.ts
@@ -1,15 +1,32 @@
 // config/astro/integrations.ts
 
 import markdoc from "@astrojs/markdoc";
+import sitemap from "@astrojs/sitemap";
 import vue from "@astrojs/vue";
 import sentry from "@sentry/astro";
 import { AstroUserConfig } from "astro";
+import { getLocalesMap } from "./i18n";
 
 export function createConfig(): AstroUserConfig["integrations"] {
   return [
     /**
      * Astro integrations
+     */
+
+    /**
+     * Requires `site` to be set in `astro.config.ts`.
      *
+     * @see https://docs.astro.build/en/guides/integrations-guide/sitemap/
+     */
+    sitemap({
+      xslURL: "/sitemap.xsl",
+      i18n: {
+        defaultLocale: "en",
+        locales: getLocalesMap(),
+      },
+    }),
+
+    /**
      * In production, ensure to bind the DSN and source map configuration properly.
      * Each integration is configured with appropriate settings for the project.
      */

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/markdoc": "^0.14.2",
+    "@astrojs/sitemap": "^3.4.0",
     "@astrojs/vue": "^5.0.13",
     "@eslint/js": "9.25.1",
     "@headlessui/vue": "^1.7.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/markdoc':
         specifier: ^0.14.2
         version: 0.14.2(astro@5.7.12(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.2)(typescript@5.8.3)(yaml@2.7.1))
+      '@astrojs/sitemap':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@astrojs/vue':
         specifier: ^5.0.13
         version: 5.0.13(@types/node@22.15.17)(astro@5.7.12(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.2)(typescript@5.8.3)(yaml@2.7.1))(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.2)(vue@3.5.13(typescript@5.8.3))(yaml@2.7.1)
@@ -187,6 +190,9 @@ packages:
   '@astrojs/prism@3.2.0':
     resolution: {integrity: sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/sitemap@3.4.0':
+    resolution: {integrity: sha512-C5m/xsKvRSILKM3hy47n5wKtTQtJXn8epoYuUmCCstaE9XBt20yInym3Bz2uNbEiNfv11bokoW0MqeXPIvjFIQ==}
 
   '@astrojs/telemetry@3.2.1':
     resolution: {integrity: sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==}
@@ -1731,6 +1737,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
   '@types/node@22.15.17':
     resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
 
@@ -1739,6 +1748,9 @@ packages:
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
@@ -2060,6 +2072,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4005,6 +4020,9 @@ packages:
   sass-formatter@0.7.9:
     resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4087,6 +4105,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@8.0.0:
+    resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    hasBin: true
+
   smol-toml@1.3.4:
     resolution: {integrity: sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==}
     engines: {node: '>= 18'}
@@ -4104,6 +4127,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4877,6 +4903,12 @@ snapshots:
   '@astrojs/prism@3.2.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/sitemap@3.4.0':
+    dependencies:
+      sitemap: 8.0.0
+      stream-replace-string: 2.0.0
+      zod: 3.24.4
 
   '@astrojs/telemetry@3.2.1':
     dependencies:
@@ -6573,6 +6605,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@17.0.45': {}
+
   '@types/node@22.15.17':
     dependencies:
       undici-types: 6.21.0
@@ -6586,6 +6620,10 @@ snapshots:
       '@types/node': 22.15.17
       pg-protocol: 1.9.5
       pg-types: 2.2.0
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 22.15.17
 
   '@types/shimmer@1.2.0': {}
 
@@ -6986,6 +7024,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -9364,6 +9404,8 @@ snapshots:
     dependencies:
       suf-log: 2.5.3
 
+  sax@1.4.1: {}
+
   semver@6.3.1: {}
 
   semver@7.7.1: {}
@@ -9510,6 +9552,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@8.0.0:
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.4.1
+
   smol-toml@1.3.4: {}
 
   source-map-js@1.2.1: {}
@@ -9519,6 +9568,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   stable-hash@0.0.5: {}
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -44,4 +44,4 @@ User-agent: Claude-Web
 Allow: /
 
 # Sitemap declaration
-Sitemap: https://onetimesecret.com/sitemap.xml
+Sitemap: https://onetimesecret.com/sitemap-index.xml

--- a/src/components/layout/LayoutHead.astro
+++ b/src/components/layout/LayoutHead.astro
@@ -134,6 +134,10 @@ const connectSrcDirective = generateCspConnectSrc(apiUrl, isDebugMode);
     breadcrumbsLd={pageBreadcrumbsLd}
   />
   <link
+    rel="sitemap"
+    href="/sitemap-index.xml"
+  />
+  <link
     rel="alternate"
     hreflang="x-default"
     href={`${siteOrigin}${basePathForAlternates}`}


### PR DESCRIPTION
Configure the sitemap integration with i18n support. Add `VITE_BASE_URL` env var for the site configuration required by the integration. Update robots.txt and add a sitemap link in the head.