### PR TITLE
[#I18N] i18n Translation updates for fr, de

### DIFF
--- a/src/i18n/ui/de.json
+++ b/src/i18n/ui/de.json
@@ -1,5 +1,6 @@
 {
   "onetime-secret-literal": "Onetime Secret",
+  "onetime-secret-literal-logo": "Onetime Secret Logo",
   "all-rights-reserved": "Alle Rechte vorbehalten",
   "read-our-latest-blog-posts": "Lesen Sie unsere neuesten Blogbeiträge",
   "view-our-subscription-pricing": "Sehen Sie unsere Abonnementpreise",
@@ -39,12 +40,15 @@
   "LABELS": {
     "about": "Über uns",
     "pricing": "Preise",
+    "create": "Erstellen",
     "blog": "Blog",
     "create_link": "Geheimen Link erstellen",
     "docs": "Dokumentation",
     "privacy-policy": "Datenschutzerklärung",
     "terms-and-conditions": "Allgemeine Geschäftsbedingungen",
     "security": "Sicherheitsmaßnahmen",
+    "paused": "Pausiert",
+    "playing": "Wird abgespielt",
     "feedback": "Rückmeldung",
     "learn-about-our-security-measures": "Informieren Sie sich über unsere Sicherheitsmaßnahmen",
     "terms": "Allgemeine Geschäftsbedingungen",
@@ -108,9 +112,10 @@
       "optionsHeading": "Datenschutzoptionen",
       "addPassphrase": "Passphrase hinzufügen",
       "secret_placeholder": "Geben Sie hier Ihre geheime Nachricht ein...",
+      "secret_placeholder_mobile": "Geheimnis hier eingeben...",
       "secret-label": "Geheimtext-Eingabe",
       "secret-description": "Geben Sie den vertraulichen Text ein, den Sie sicher teilen möchten. Dieser Text wird verschlüsselt und ist nur einmal verfügbar.",
-      "secret_placeholder-premium": "Geben Sie hier Ihre geheime Nachricht ein (gespeichert in {noun})",
+      "secret_placeholder_stored": "Geben Sie hier Ihre geheime Nachricht ein (gespeichert in {noun})",
       "dataSovereignty": "Datensouveränität",
       "regionExplanation": "Ihre Geheimnisse bleiben in der von Ihnen ausgewählten Region. Dies hilft, Anforderungen an den Datenstandort und Datenschutzbestimmungen wie die DSGVO zu erfüllen.",
       "learn_more_regions": "Erfahren Sie mehr über regionale Domains",
@@ -201,7 +206,9 @@
         "title": "Eigene Domain & Branding",
         "subtitle": "Stärken Sie Ihre Marke und schaffen Sie Vertrauen durch Verwendung Ihrer eigenen Domain und Ihres Logos.",
         "learn_more": "Mehr erfahren",
-        "view_pricing": "Preise anzeigen"
+        "sr_description": "Ein Bildkarussell mit Screenshots von Beispielen für die Verwendung von Onetime Secret mit individueller Markengestaltung.",
+        "view_pricing": "Preise anzeigen",
+        "toggle_animation": "Animation umschalten"
       },
       "featureHighlights": {
         "sectionTitle": "Hauptfunktionen",

--- a/src/i18n/ui/fr.json
+++ b/src/i18n/ui/fr.json
@@ -1,5 +1,6 @@
 {
   "onetime-secret-literal": "Onetime Secret",
+  "onetime-secret-literal-logo": "Logo Onetime Secret",
   "all-rights-reserved": "Tous droits réservés",
   "read-our-latest-blog-posts": "Lisez nos derniers articles de blog",
   "view-our-subscription-pricing": "Consultez nos tarifs d'abonnement",
@@ -39,12 +40,15 @@
   "LABELS": {
     "about": "À propos",
     "pricing": "Tarifs",
+    "create": "Créer",
     "blog": "Blog",
     "create_link": "Créer un lien secret",
     "docs": "Documentation",
     "privacy-policy": "Politique de confidentialité",
     "terms-and-conditions": "Conditions générales",
     "security": "Mesures de sécurité",
+    "paused": "En pause",
+    "playing": "En lecture",
     "feedback": "Avis",
     "learn-about-our-security-measures": "En savoir plus sur nos mesures de sécurité",
     "terms": "Conditions",
@@ -108,9 +112,10 @@
       "optionsHeading": "Options de confidentialité",
       "addPassphrase": "Ajouter une phrase de passe",
       "secret_placeholder": "Saisissez votre message secret ici...",
+      "secret_placeholder_mobile": "Saisissez votre secret ici...",
       "secret-label": "Saisie de texte secret",
       "secret-description": "Saisissez le texte sensible que vous souhaitez partager en toute sécurité. Ce texte sera crypté et disponible une seule fois.",
-      "secret_placeholder-premium": "Saisissez votre message secret ici (stocké en {noun})",
+      "secret_placeholder_stored": "Saisissez votre message secret ici (stocké en {noun})",
       "dataSovereignty": "Souveraineté des données",
       "regionExplanation": "Vos secrets restent dans la région que vous avez sélectionnée. Cela permet de répondre aux exigences de résidence des données et aux réglementations sur la confidentialité telles que le RGPD.",
       "learn_more_regions": "En savoir plus sur les domaines régionaux",
@@ -201,7 +206,9 @@
         "title": "Domaine personnalisé et image de marque",
         "subtitle": "Renforcez votre marque et établissez la confiance en utilisant votre propre domaine et logo.",
         "learn_more": "En savoir plus",
-        "view_pricing": "Voir les tarifs"
+        "sr_description": "Un carrousel d'images montrant des captures d'écran d'exemples d'utilisation d'Onetime Secret avec une personnalisation de marque.",
+        "view_pricing": "Voir les tarifs",
+        "toggle_animation": "Activer/désactiver l'animation"
       },
       "featureHighlights": {
         "sectionTitle": "Fonctionnalités principales",


### PR DESCRIPTION
Summary:
1. German translations:
   - "Onetime Secret logo" → "Onetime Secret Logo"
   - "Create" → "Erstellen"
   - "Paused" → "Pausiert"
   - "Playing" → "Wird abgespielt"
   - "Type secret here..." → "Geheimnis hier eingeben..."
   - "Type your secret message here (stored in {noun})" → "Geben Sie hier Ihre geheime Nachricht ein (gespeichert in {noun})"
   - "An image carousel showing screenshots..." → "Ein Bildkarussell mit Screenshots..."
   - "Toggle animation" → "Animation umschalten"

2. French translations:
   - "Onetime Secret logo" → "Logo Onetime Secret"
   - "Create" → "Créer"
   - "Paused" → "En pause"
   - "Playing" → "En lecture"
   - "Type secret here..." → "Saisissez votre secret ici..."
   - "Type your secret message here (stored in {noun})" → "Saisissez votre message secret ici (stocké en {noun})"
   - "An image carousel showing screenshots..." → "Un carrousel d'images montrant des captures d'écran..."
   - "Toggle animation" → "Activer/désactiver l'animation"

All English strings have been translated to their respective languages while maintaining consistency with the existing translations.