### PR TITLE
Load target language messages in getContentPageData

### DIFF
--- a/src/utils/contentPage.ts
+++ b/src/utils/contentPage.ts
@@ -32,10 +32,23 @@ export async function getContentPageData(
   lang: SupportedLanguage = DEFAULT_LANGUAGE,
   slug: string
 ): Promise<ContentPageData> {
-  // Setup initial messages for i18n
-  const initialMessages = {
+  // Setup initial messages for i18n - include both English and target language
+  const initialMessages: Record<string, MessageSchema> = {
     [DEFAULT_LANGUAGE]: enMessages as MessageSchema,
   };
+
+  // Load the target language messages if not English
+  if (lang !== DEFAULT_LANGUAGE) {
+    try {
+      const langMessagesModule = await import(`@/i18n/ui/${lang}.json`);
+      initialMessages[lang] = (langMessagesModule.default || langMessagesModule) as MessageSchema;
+    } catch (error) {
+      console.warn(
+        `Failed to load messages for language "${lang}" in getContentPageData. English fallback will be used.`,
+        error
+      );
+    }
+  }
 
   // Initialize i18n for page content
   await createLocaleI18n(lang, initialMessages);


### PR DESCRIPTION
### **User description**
Fix missing translations on about page by loading both English and target language messages in getContentPageData function.

Previously only English messages were loaded, causing Spanish and other non-English pages to show fallback warnings for all translation keys. Now matches the behavior of getLanguagePaths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Load target language messages in getContentPageData function

- Fix missing translations on non-English about pages

- Add dynamic language message loading with error handling

- Match behavior of getLanguagePaths for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getContentPageData called<br/>with lang parameter"] --> B{"lang ===<br/>DEFAULT_LANGUAGE?"}
  B -->|Yes| C["Load English messages only"]
  B -->|No| D["Load English + target<br/>language messages"]
  D --> E{"Import successful?"}
  E -->|Yes| F["Use target language<br/>messages"]
  E -->|No| G["Log warning, use<br/>English fallback"]
  C --> H["Initialize i18n"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contentPage.ts</strong><dd><code>Add dynamic target language message loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/contentPage.ts

<ul><li>Added type annotation <code>Record<string, MessageSchema></code> to <code>initialMessages</code><br> <li> Implemented conditional loading of target language messages when <code>lang </code><br><code>!== DEFAULT_LANGUAGE</code><br> <li> Added dynamic import of language-specific JSON files from <br><code>@/i18n/ui/${lang}.json</code><br> <li> Added try-catch error handling with console warning for failed <br>language imports<br> <li> Ensures fallback to English when target language loading fails</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret.com/pull/79/files#diff-4af08441bc612c4305d28524a18beaf80f80c55cddc390db299daa35cd198ced">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

