### PR TITLE
Fix: Prevent CDN file removal on deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,5 +114,5 @@ jobs:
           storagePassword: "${{ secrets.STORAGE_PASSWORD_RW }}" # Password for storage zone access
           pullZoneId: "${{ secrets.PULL_ZONE_ID }}" # Your BunnyCDN pull zone ID
           upload: "true" # Upload new files
-          remove: "true" # Remove files that don't exist locally
+          remove: "false" # Remove files that don't exist locally
           purgePullZone: "true" # Purge the CDN cache after deployment

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -114,5 +114,5 @@ jobs:
           storagePassword: "${{ secrets.STORAGE_PASSWORD_RW }}" # Password for storage zone access (use secrets context)
           pullZoneId: "${{ secrets.PULL_ZONE_ID }}" # Your BunnyCDN pull zone ID (use secrets context)
           upload: "true" # Upload new files
-          remove: "true" # Remove files that don't exist locally
+          remove: "false" # Remove files that don't exist locally
           purgePullZone: "true" # Purge the CDN cache after deployment


### PR DESCRIPTION
### **User description**
remove=false prevents the race condition where old assets are deleted
before new ones are uploaded:
- Pro: No broken window during deployment
- Con: Old assets accumulate (minor storage cost)


___

### **PR Type**
Bug fix


___

### **Description**
- Disable CDN file removal during deployment to prevent race conditions

- Prevents broken window when old assets deleted before new ones uploaded

- Applies change to both production and staging deployment workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy Workflow"] -->|"remove: true"| B["Delete Old Assets"]
  B -->|"Race Condition"| C["Broken Window"]
  A -->|"remove: false"| D["Keep Old Assets"]
  D -->|"No Race Condition"| E["Safe Deployment"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-production.yml</strong><dd><code>Disable CDN file removal in production deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-production.yml

<ul><li>Changed <code>remove</code> parameter from <code>"true"</code> to <code>"false"</code> in BunnyCDN sync step<br> <li> Prevents deletion of old assets before new ones are uploaded<br> <li> Eliminates race condition that causes broken window during deployment</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret.com/pull/97/files#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deploy-staging.yml</strong><dd><code>Disable CDN file removal in staging deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-staging.yml

<ul><li>Changed <code>remove</code> parameter from <code>"true"</code> to <code>"false"</code> in BunnyCDN sync step<br> <li> Prevents deletion of old assets before new ones are uploaded<br> <li> Eliminates race condition that causes broken window during deployment</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret.com/pull/97/files#diff-98b468326a86981405fb6e13c66ea8cd0032c4c7e4f2816fbc42a1fa9b32e991">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

