### PR TITLE
Fix missing UK endpoint in CSP connect-src

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -18,6 +18,7 @@ export function generateCspConnectSrc(
     "https://ca.onetimesecret.com", // Regional endpoint
     "https://nz.onetimesecret.com", // Regional endpoint
     "https://us.onetimesecret.com", // Regional endpoint
+    "https://uk.onetimesecret.com", // Regional endpoint
   ];
 
   // In debug mode, allow connection to the Sentry debugging sidecar.


### PR DESCRIPTION
## Summary

- Adds `https://uk.onetimesecret.com` to the `connect-src` CSP directive in `src/utils/security.ts`
- Without this, browsers silently block all fetch requests to the UK regional endpoint with `TypeError: Failed to fetch` — no network request is ever made

## Test plan

- [ ] Visit a page that makes API calls to the UK endpoint
- [ ] Confirm no CSP violations in the browser console
- [ ] Confirm fetch requests to `https://uk.onetimesecret.com` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)