### PR TITLE
Fix empty passphrase submitted when no passphrase is set

### DIFF
--- a/src/components/vue/forms/SecretForm.vue
+++ b/src/components/vue/forms/SecretForm.vue
@@ -154,7 +154,6 @@ const handleCreateLink = async () => {
   const payload: any = {
     secret: secretText.value,
     ttl: secretOptions.value.ttl,
-    passphrase: null,
   };
 
   if (secretOptions.value.addPassphrase) {


### PR DESCRIPTION
## Summary

- Removes `passphrase: null` from the default API payload in `SecretForm.vue`
- The `passphrase` field is now only included when the user checks "Require passphrase" and enters a value
- Previously, every secret creation request sent `passphrase: null`, which the API interpreted as an empty-string passphrase — causing recipients to see a "This message requires a passphrase" prompt even for secrets created without one

## Test plan

- [ ] Create a secret without checking "Require passphrase" — recipient should see no passphrase prompt
- [ ] Create a secret with "Require passphrase" checked and a passphrase entered — recipient should be prompted for the passphrase
- [ ] Verify the network request payload omits the `passphrase` field entirely in the first case

🤖 Generated with [Claude Code](https://claude.com/claude-code)