### PR TITLE
i18n: Translate German, French, and Spanish UI strings

### DIFF
--- a/src/i18n/ui/de.json
+++ b/src/i18n/ui/de.json
@@ -105,7 +105,7 @@
       "features": "Funktionen",
       "elevate-your-secure-sharing-with-custom-domains-": "Verbessern Sie Ihr sicheres Teilen mit benutzerdefinierten Domains, unbegrenzter Kapazität und Funktionen auf Unternehmensniveau.",
       "payment-frequency": "Zahlungsfrequenz",
-      "region-selector-label": "Zahlungsregion:",
+      "region-selector-label": "Datenregion:",
       "region": "Region",
       "change": "Ändern",
       "secure-your-brand-and-build-customer-trust-with-": "Sichern Sie Ihre Marke und bauen Sie Kundenvertrauen mit Links von Ihrer Domain auf. Perfekt für Unternehmen, die Wert auf Datenschutz und Professionalität legen.",
@@ -152,11 +152,11 @@
             "annually": "356 €"
           },
           "features": {
-            "0": "Alles aus Basis",
-            "1": "Unbegrenzte benutzerdefinierte Domains",
-            "2": "Benutzerdefiniertes Branding mit Ihrem Logo",
-            "3": "Ablaufzeit bis zu 30 Tage",
-            "4": "Startseiten-Zugriffskontrolle (bestimmen Sie, wer Geheimnisse auf Ihrer Domain erstellen kann)"
+            "0": "Alles aus Basis, mit unbegrenzten Domains",
+            "1": "Benutzerdefiniertes Branding mit Ihrem Logo",
+            "2": "Ablaufzeit bis zu 30 Tage",
+            "3": "Unbegrenzt viele Mitglieder einladen",
+            "4": "Startseiten-Zugriffskontrollen, Eingehende Geheimnisse"
           }
         }
       },
@@ -185,8 +185,8 @@
     "errors": {
       "errorTitle": "Nicht erfolgreich",
       "passphraseRequired": "Passphrase ist erforderlich, wenn diese Option ausgewählt ist.",
-      "apiGenericErrorHomepage": "Something went wrong. Please try again.",
-      "apiGenericError": "Something went wrong. Please try again."
+      "apiGenericErrorHomepage": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
+      "apiGenericError": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
     },
     "secrets": {
       "keepSensitiveInfo": "Halten Sie sensible Informationen aus Ihren E-Mails und Chat-Protokollen heraus.",
@@ -251,11 +251,11 @@
       "privacyNote": "Ihre Geheimnisse werden verschlüsselt, nie in Protokollen gespeichert und nach dem Anzeigen automatisch gelöscht.",
       "itdevops": {
         "title": "IT & DevOps",
-        "description": "Securely rotate production credentials, share API keys during onboarding, and keep sensitive config out of Slack and email threads."
+        "description": "Rotieren Sie Produktions-Zugangsdaten sicher, teilen Sie API-Schlüssel beim Onboarding und halten Sie sensible Konfigurationen aus Slack- und E-Mail-Verläufen heraus."
       },
       "consultants": {
-        "title": "Consultants & Agencies",
-        "description": "Share client credentials, project access, and sensitive deliverables without leaving traces in email threads or shared drives."
+        "title": "Berater & Agenturen",
+        "description": "Teilen Sie Kundenzugangsdaten, Projektzugriffe und vertrauliche Arbeitsergebnisse, ohne Spuren in E-Mail-Verläufen oder gemeinsamen Laufwerken zu hinterlassen."
       },
       "it": {
         "title": "IT-Fachkraft",
@@ -280,8 +280,8 @@
         "cta": "Sichern Sie Ihre API-Schlüssel"
       },
       "hr": {
-        "title": "HR-Manager",
-        "description": "Teilen Sie sensible Mitarbeiterinformationen und Anmeldedaten sicher",
+        "title": "HR & People Ops",
+        "description": "Teilen Sie Onboarding-Zugangsdaten, temporäre Systemzugriffe und vertrauliche HR-Kommunikation, ohne Spuren in E-Mails oder Ticketsystemen zu hinterlassen.",
         "benefits": {
           "1": "Übermitteln Sie Onboarding-Anmeldedaten sicher an neue Mitarbeiter",
           "2": "Teilen Sie vertrauliche Informationen mit einmaligem Zugriff",
@@ -291,8 +291,8 @@
         "cta": "Sichere HR-Kommunikation"
       },
       "legal": {
-        "title": "Rechtsteam",
-        "description": "Teilen Sie vertrauliche Rechtsdokumente und Informationen sicher",
+        "title": "Recht & Finanzen",
+        "description": "Übermitteln Sie Vergleichsbedingungen, Kontozugangsdaten und vertrauliche Fallinformationen mit Einmalzugriffskontrollen, die das Anwaltsgeheimnis und die Vertraulichkeit schützen.",
         "benefits": {
           "1": "Wahren Sie das Anwaltsgeheimnis in der digitalen Kommunikation",
           "2": "Teilen Sie fallsensible Informationen sicher mit Mandanten",
@@ -304,13 +304,13 @@
     },
     "footer": {
       "columns": {
-        "product": "Product"
+        "product": "Produkt"
       },
       "links": {
         "api": "API",
         "changelog": "Changelog",
         "github": "GitHub",
-        "contact": "Contact",
+        "contact": "Kontakt",
         "dpa": "DPA",
         "guides": "Anleitungen",
         "selfHosting": "Self-Hosting"
@@ -324,9 +324,9 @@
         "badge": "Datenschutzorientiertes Design",
         "title": {
           "line1": "Onetime Secret",
-          "line2_w1": "Signed.",
-          "line2_w2": "Sealed.",
-          "line2_w3": "Delivered."
+          "line2_w1": "Signiert.",
+          "line2_w2": "Versiegelt.",
+          "line2_w3": "Zugestellt."
         },
         "subtitle": "Senden Sie Passwörter, Zugangsdaten und sensible Informationen über Links, die nur einmal funktionieren.",
         "compliance": {
@@ -338,19 +338,19 @@
         }
       },
       "features": {
-        "label": "Security architecture",
-        "heading": "Built to forget.",
-        "description": "Every design decision serves one purpose: make sure secrets are readable exactly once, then gone."
+        "label": "Sicherheitsarchitektur",
+        "heading": "Gebaut, um zu vergessen.",
+        "description": "Jede Designentscheidung dient einem einzigen Zweck: dafür zu sorgen, dass Geheimnisse genau einmal lesbar sind und dann verschwinden."
       },
       "useCases": {
-        "label": "Use cases",
-        "heading": "How teams use Onetime Secret",
-        "description": "From onboarding a new hire to rotating production credentials, sensitive data moves through organizations every day."
+        "label": "Anwendungsfälle",
+        "heading": "Wie Teams Onetime Secret nutzen",
+        "description": "Vom Onboarding neuer Mitarbeiter bis zum Rotieren von Produktions-Zugangsdaten — sensible Daten bewegen sich täglich durch Unternehmen."
       },
       "infrastructure": {
-        "label": "Global infrastructure",
-        "heading": "Your data, your jurisdiction.",
-        "description": "Choose where your secrets are stored and processed. Regional instances ensure your data never leaves the geography you choose.",
+        "label": "Globale Infrastruktur",
+        "heading": "Ihre Daten, Ihr Rechtsraum.",
+        "description": "Wählen Sie, wo Ihre Geheimnisse gespeichert und verarbeitet werden. Regionale Instanzen stellen sicher, dass Ihre Daten die von Ihnen gewählte Region niemals verlassen.",
         "regions": {
           "ca": "Toronto, Kanada",
           "eu": "Nürnberg, Deutschland",
@@ -358,24 +358,24 @@
           "uk": "London, Vereinigtes Königreich",
           "us": "Hillsboro, Vereinigte Staaten"
         },
-        "capabilitiesLabel": "Available regions",
+        "capabilitiesLabel": "Verfügbare Regionen",
         "features": {
-          "customDomain": "Custom Domain",
+          "customDomain": "Benutzerdefinierte Domain",
           "customBranding": "Benutzerdefiniertes Branding",
           "sso": "SSO / SAML",
           "incomingSecrets": "Eingehende Geheimnisse",
           "accessControls": "Zugriffskontrollen",
-          "auditLogs": "Audit Logs"
+          "auditLogs": "Audit-Logs"
         }
       },
       "cta": {
         "heading": {
-          "line1": "Start sharing secrets",
-          "line2": "the right way."
+          "line1": "Teilen Sie Geheimnisse",
+          "line2": "auf die richtige Weise."
         },
         "description": "Kostenlos für Einzelpersonen und Teams. Pläne für individuelles Branding, erweiterte Steuerung und mehr.",
-        "primaryButton": "Try it free",
-        "secondaryButton": "View pricing"
+        "primaryButton": "Kostenlos testen",
+        "secondaryButton": "Preise anzeigen"
       },
       "howItWorks": {
         "label": "So funktioniert es",
@@ -444,8 +444,8 @@
     "next": "Nächster",
     "back": "Zurück zu allen Updates",
     "nav-label": "Änderungsprotokoll-Navigation",
-    "category-release": "Release",
-    "category-news": "News",
+    "category-release": "Veröffentlichung",
+    "category-news": "Neuigkeiten",
     "category-operations": "Betrieb",
     "category-security": "Sicherheit",
     "before": "Vorher",

--- a/src/i18n/ui/es.json
+++ b/src/i18n/ui/es.json
@@ -280,8 +280,8 @@
         "cta": "Asegure sus claves API"
       },
       "hr": {
-        "title": "RR. HH. y People Ops",
-        "description": "Comparta credenciales de incorporación, accesos temporales a sistemas y comunicaciones confidenciales de RR. HH. sin dejar rastro en el correo electrónico o los sistemas de tickets.",
+        "title": "RH y People Ops",
+        "description": "Comparta credenciales de incorporación, accesos temporales a sistemas y comunicaciones confidenciales de RH sin dejar rastro en el correo electrónico o los sistemas de tickets.",
         "benefits": {
           "1": "Transmita credenciales de incorporación de forma segura a nuevos empleados",
           "2": "Comparta información confidencial con acceso de un solo uso",

--- a/src/i18n/ui/es.json
+++ b/src/i18n/ui/es.json
@@ -105,7 +105,7 @@
       "features": "Características",
       "elevate-your-secure-sharing-with-custom-domains-": "Mejore su intercambio seguro con dominios personalizados, capacidad ilimitada y características de nivel empresarial.",
       "payment-frequency": "Frecuencia de pago",
-      "region-selector-label": "Región de pago:",
+      "region-selector-label": "Región de datos:",
       "region": "Región",
       "change": "Cambiar",
       "secure-your-brand-and-build-customer-trust-with-": "Asegure su marca y genere confianza con los clientes mediante enlaces de su dominio. Perfecto para empresas que valoran la privacidad y el profesionalismo.",
@@ -152,11 +152,11 @@
             "annually": "$356"
           },
           "features": {
-            "0": "Todo lo incluido en Básico",
-            "1": "Dominios personalizados ilimitados",
-            "2": "Marca personalizada con su logotipo",
-            "3": "Caducidad hasta 30 días",
-            "4": "Control de acceso a la página de inicio (decida quién puede crear secretos en su dominio)"
+            "0": "Todo lo incluido en Básico, con dominios ilimitados",
+            "1": "Marca personalizada con su logotipo",
+            "2": "Caducidad hasta 30 días",
+            "3": "Invite a miembros ilimitados",
+            "4": "Controles de acceso a la página de inicio, Secretos entrantes"
           }
         }
       },
@@ -185,8 +185,8 @@
     "errors": {
       "errorTitle": "No exitoso",
       "passphraseRequired": "Se requiere una frase de contraseña cuando la opción está seleccionada.",
-      "apiGenericErrorHomepage": "Something went wrong. Please try again.",
-      "apiGenericError": "Something went wrong. Please try again."
+      "apiGenericErrorHomepage": "Algo salió mal. Inténtelo de nuevo.",
+      "apiGenericError": "Algo salió mal. Inténtelo de nuevo."
     },
     "secrets": {
       "keepSensitiveInfo": "Mantenga la información sensible fuera de sus correos electrónicos y registros de chat.",
@@ -250,12 +250,12 @@
       "complianceInfo": "Información de cumplimiento",
       "privacyNote": "Sus secretos están encriptados, nunca se almacenan en registros y se eliminan automáticamente después de verlos.",
       "itdevops": {
-        "title": "IT & DevOps",
-        "description": "Securely rotate production credentials, share API keys during onboarding, and keep sensitive config out of Slack and email threads."
+        "title": "TI y DevOps",
+        "description": "Rote credenciales de producción de forma segura, comparta claves de API durante la incorporación y mantenga la configuración sensible fuera de Slack y los hilos de correo electrónico."
       },
       "consultants": {
-        "title": "Consultants & Agencies",
-        "description": "Share client credentials, project access, and sensitive deliverables without leaving traces in email threads or shared drives."
+        "title": "Consultores y agencias",
+        "description": "Comparta credenciales de clientes, accesos a proyectos y entregables confidenciales sin dejar rastros en hilos de correo electrónico o unidades compartidas."
       },
       "it": {
         "title": "Profesional de TI",
@@ -280,8 +280,8 @@
         "cta": "Asegure sus claves API"
       },
       "hr": {
-        "title": "Gerente de Recursos Humanos",
-        "description": "Comparta información sensible de empleados y credenciales de forma segura",
+        "title": "RR. HH. y People Ops",
+        "description": "Comparta credenciales de incorporación, accesos temporales a sistemas y comunicaciones confidenciales de RR. HH. sin dejar rastro en el correo electrónico o los sistemas de tickets.",
         "benefits": {
           "1": "Transmita credenciales de incorporación de forma segura a nuevos empleados",
           "2": "Comparta información confidencial con acceso de un solo uso",
@@ -291,8 +291,8 @@
         "cta": "Asegure las comunicaciones de RH"
       },
       "legal": {
-        "title": "Equipo legal",
-        "description": "Comparta documentos legales confidenciales e información de forma segura",
+        "title": "Legal y Finanzas",
+        "description": "Transmita términos de acuerdos, credenciales de cuentas e información confidencial de casos con controles de acceso de un solo uso que protegen el privilegio y la confidencialidad.",
         "benefits": {
           "1": "Mantenga el privilegio abogado-cliente en comunicaciones digitales",
           "2": "Comparta información sensible de casos con clientes de forma segura",
@@ -304,13 +304,13 @@
     },
     "footer": {
       "columns": {
-        "product": "Product"
+        "product": "Producto"
       },
       "links": {
         "api": "API",
         "changelog": "Changelog",
         "github": "GitHub",
-        "contact": "Contact",
+        "contact": "Contacto",
         "dpa": "DPA",
         "guides": "Guías",
         "selfHosting": "Autoalojamiento"
@@ -324,9 +324,9 @@
         "badge": "Diseño orientado a la privacidad",
         "title": {
           "line1": "Onetime Secret",
-          "line2_w1": "Signed.",
-          "line2_w2": "Sealed.",
-          "line2_w3": "Delivered."
+          "line2_w1": "Firmado.",
+          "line2_w2": "Sellado.",
+          "line2_w3": "Entregado."
         },
         "subtitle": "Envíe contraseñas, credenciales y datos sensibles con enlaces que funcionan una sola vez.",
         "compliance": {
@@ -338,19 +338,19 @@
         }
       },
       "features": {
-        "label": "Security architecture",
-        "heading": "Built to forget.",
-        "description": "Every design decision serves one purpose: make sure secrets are readable exactly once, then gone."
+        "label": "Arquitectura de seguridad",
+        "heading": "Diseñado para olvidar.",
+        "description": "Cada decisión de diseño tiene un único propósito: garantizar que los secretos se puedan leer exactamente una vez y luego desaparezcan."
       },
       "useCases": {
-        "label": "Use cases",
-        "heading": "How teams use Onetime Secret",
-        "description": "From onboarding a new hire to rotating production credentials, sensitive data moves through organizations every day."
+        "label": "Casos de uso",
+        "heading": "Cómo los equipos usan Onetime Secret",
+        "description": "Desde la incorporación de un nuevo empleado hasta la rotación de credenciales de producción, los datos sensibles circulan por las organizaciones todos los días."
       },
       "infrastructure": {
-        "label": "Global infrastructure",
-        "heading": "Your data, your jurisdiction.",
-        "description": "Choose where your secrets are stored and processed. Regional instances ensure your data never leaves the geography you choose.",
+        "label": "Infraestructura global",
+        "heading": "Sus datos, su jurisdicción.",
+        "description": "Elija dónde se almacenan y procesan sus secretos. Las instancias regionales garantizan que sus datos nunca salgan de la región que elija.",
         "regions": {
           "ca": "Toronto, Canadá",
           "eu": "Núremberg, Alemania",
@@ -358,24 +358,24 @@
           "uk": "Londres, Reino Unido",
           "us": "Hillsboro, Estados Unidos"
         },
-        "capabilitiesLabel": "Available regions",
+        "capabilitiesLabel": "Regiones disponibles",
         "features": {
-          "customDomain": "Custom Domain",
+          "customDomain": "Dominio personalizado",
           "customBranding": "Marca personalizada",
           "sso": "SSO / SAML",
           "incomingSecrets": "Secretos entrantes",
           "accessControls": "Controles de acceso",
-          "auditLogs": "Audit Logs"
+          "auditLogs": "Registros de auditoría"
         }
       },
       "cta": {
         "heading": {
-          "line1": "Start sharing secrets",
-          "line2": "the right way."
+          "line1": "Comparta secretos",
+          "line2": "de la forma correcta."
         },
         "description": "Gratis para particulares y equipos. Planes para marca personalizada, controles avanzados y más.",
-        "primaryButton": "Try it free",
-        "secondaryButton": "View pricing"
+        "primaryButton": "Pruébelo gratis",
+        "secondaryButton": "Ver precios"
       },
       "howItWorks": {
         "label": "Cómo funciona",

--- a/src/i18n/ui/fr.json
+++ b/src/i18n/ui/fr.json
@@ -98,14 +98,14 @@
     "pricing": {
       "title": "Plans tarifaires | Onetime Secret",
       "description": "Choisissez le plan parfait pour vos besoins de partage d'informations sécurisées. Des plans gratuits de base aux options premium avec domaines personnalisés et infrastructure dédiée.",
-      "includes-all-features-and-unlimited-sharing-capa": "Comprend toutes les fonctionnalités et une capacité de partage illimitée",
-      "includes-all-data-locality-options": "Tous les forfaits incluent le choix de localité des données : régions {0}",
+      "includes-all-features-and-unlimited-sharing-capa": "Tous les forfaits incluent des fonctionnalités de confidentialité et une capacité de partage illimitée",
+      "includes-all-data-locality-options": "Tous les forfaits incluent le choix de localité des données : {0} régions",
       "get-started": "Commencer",
-      "frequency-value-annually-annual-monthly-subscrip": "{0} souscription",
+      "frequency-value-annually-annual-monthly-subscrip": "Abonnement {0}",
       "features": "Caractéristiques",
       "elevate-your-secure-sharing-with-custom-domains-": "Améliorez votre partage sécurisé avec des domaines personnalisés, une capacité illimitée et des fonctionnalités de niveau entreprise.",
       "payment-frequency": "Fréquence des paiements",
-      "region-selector-label": "Région de paiement :",
+      "region-selector-label": "Région des données :",
       "region": "Région",
       "change": "Changer",
       "secure-your-brand-and-build-customer-trust-with-": "Protégez votre marque et renforcez la confiance de vos clients grâce à des liens provenant de votre domaine. Parfait pour les entreprises qui accordent de l'importance à la confidentialité et au professionnalisme.",
@@ -152,11 +152,11 @@
             "annually": "356 €"
           },
           "features": {
-            "0": "Tout ce qui est inclus dans Basique",
-            "1": "Domaines personnalisés illimités",
-            "2": "Image de marque personnalisée avec votre logo",
-            "3": "Expiration jusqu'à 30 jours",
-            "4": "Contrôle d'accès à la page d'accueil (décidez qui peut créer des secrets sur votre domaine)"
+            "0": "Tout ce qui est inclus dans Basique, avec des domaines illimités",
+            "1": "Image de marque personnalisée avec votre logo",
+            "2": "Expiration jusqu'à 30 jours",
+            "3": "Invitez un nombre illimité de membres",
+            "4": "Contrôles d'accès à la page d'accueil, Secrets entrants"
           }
         }
       },
@@ -185,8 +185,8 @@
     "errors": {
       "errorTitle": "Échec",
       "passphraseRequired": "Une phrase de passe est requise lorsque l'option est sélectionnée.",
-      "apiGenericErrorHomepage": "Something went wrong. Please try again.",
-      "apiGenericError": "Something went wrong. Please try again."
+      "apiGenericErrorHomepage": "Une erreur s'est produite. Veuillez réessayer.",
+      "apiGenericError": "Une erreur s'est produite. Veuillez réessayer."
     },
     "secrets": {
       "keepSensitiveInfo": "Gardez les informations sensibles hors de vos e-mails et de vos journaux de discussion.",
@@ -251,11 +251,11 @@
       "privacyNote": "Vos secrets sont chiffrés, jamais stockés dans les journaux et automatiquement supprimés après consultation.",
       "itdevops": {
         "title": "IT & DevOps",
-        "description": "Securely rotate production credentials, share API keys during onboarding, and keep sensitive config out of Slack and email threads."
+        "description": "Renouvelez les identifiants de production en toute sécurité, partagez les clés d'API lors de l'intégration et gardez les configurations sensibles hors de Slack et des fils d'e-mails."
       },
       "consultants": {
-        "title": "Consultants & Agencies",
-        "description": "Share client credentials, project access, and sensitive deliverables without leaving traces in email threads or shared drives."
+        "title": "Consultants et agences",
+        "description": "Partagez les identifiants des clients, les accès aux projets et les livrables sensibles sans laisser de traces dans les fils d'e-mails ou les lecteurs partagés."
       },
       "it": {
         "title": "Professionnel de l'informatique",
@@ -280,8 +280,8 @@
         "cta": "Sécurisez vos clés API"
       },
       "hr": {
-        "title": "Responsable RH",
-        "description": "Partagez en toute sécurité les informations sensibles des employés et les informations d'identification.",
+        "title": "RH et People Ops",
+        "description": "Partagez les identifiants d'intégration, les accès temporaires aux systèmes et les communications RH confidentielles sans laisser de trace dans les e-mails ou les systèmes de tickets.",
         "benefits": {
           "1": "Transmettez en toute sécurité les informations d'identification d'intégration aux nouveaux employés.",
           "2": "Partagez des informations confidentielles avec un accès unique.",
@@ -291,8 +291,8 @@
         "cta": "Sécurisez les communications RH"
       },
       "legal": {
-        "title": "Équipe juridique",
-        "description": "Partagez des documents juridiques confidentiels et des informations en toute sécurité.",
+        "title": "Juridique et Finance",
+        "description": "Transmettez les conditions de règlement, les identifiants de compte et les informations confidentielles relatives aux affaires grâce à des contrôles d'accès à usage unique qui protègent le secret professionnel et la confidentialité.",
         "benefits": {
           "1": "Maintenez le secret professionnel dans les communications numériques.",
           "2": "Partagez en toute sécurité des informations sensibles relatives aux affaires avec les clients.",
@@ -304,7 +304,7 @@
     },
     "footer": {
       "columns": {
-        "product": "Product"
+        "product": "Produit"
       },
       "links": {
         "api": "API",
@@ -324,9 +324,9 @@
         "badge": "Conception axée sur la vie privée",
         "title": {
           "line1": "Onetime Secret",
-          "line2_w1": "Signed.",
-          "line2_w2": "Sealed.",
-          "line2_w3": "Delivered."
+          "line2_w1": "Signé.",
+          "line2_w2": "Scellé.",
+          "line2_w3": "Livré."
         },
         "subtitle": "Envoyez des mots de passe, des identifiants et des données sensibles avec des liens à usage unique.",
         "compliance": {
@@ -338,19 +338,19 @@
         }
       },
       "features": {
-        "label": "Security architecture",
-        "heading": "Built to forget.",
-        "description": "Every design decision serves one purpose: make sure secrets are readable exactly once, then gone."
+        "label": "Architecture de sécurité",
+        "heading": "Conçu pour oublier.",
+        "description": "Chaque décision de conception sert un seul objectif : garantir que les secrets sont lisibles exactement une fois, puis disparaissent."
       },
       "useCases": {
-        "label": "Use cases",
-        "heading": "How teams use Onetime Secret",
-        "description": "From onboarding a new hire to rotating production credentials, sensitive data moves through organizations every day."
+        "label": "Cas d'usage",
+        "heading": "Comment les équipes utilisent Onetime Secret",
+        "description": "De l'intégration d'un nouvel employé à la rotation des identifiants de production, les données sensibles circulent chaque jour dans les organisations."
       },
       "infrastructure": {
-        "label": "Global infrastructure",
-        "heading": "Your data, your jurisdiction.",
-        "description": "Choose where your secrets are stored and processed. Regional instances ensure your data never leaves the geography you choose.",
+        "label": "Infrastructure mondiale",
+        "heading": "Vos données, votre juridiction.",
+        "description": "Choisissez où vos secrets sont stockés et traités. Les instances régionales garantissent que vos données ne quittent jamais la zone géographique que vous avez choisie.",
         "regions": {
           "ca": "Toronto, Canada",
           "eu": "Nuremberg, Allemagne",
@@ -358,24 +358,24 @@
           "uk": "Londres, Royaume-Uni",
           "us": "Hillsboro, États-Unis"
         },
-        "capabilitiesLabel": "Available regions",
+        "capabilitiesLabel": "Régions disponibles",
         "features": {
-          "customDomain": "Custom Domain",
+          "customDomain": "Domaine personnalisé",
           "customBranding": "Image de marque personnalisée",
           "sso": "SSO / SAML",
           "incomingSecrets": "Secrets entrants",
           "accessControls": "Contrôles d'accès",
-          "auditLogs": "Audit Logs"
+          "auditLogs": "Journaux d'audit"
         }
       },
       "cta": {
         "heading": {
-          "line1": "Start sharing secrets",
-          "line2": "the right way."
+          "line1": "Partagez des secrets",
+          "line2": "de la bonne manière."
         },
         "description": "Gratuit pour les particuliers et les équipes. Des forfaits pour la personnalisation de marque, les contrôles avancés et plus encore.",
-        "primaryButton": "Try it free",
-        "secondaryButton": "View pricing"
+        "primaryButton": "Essayer gratuitement",
+        "secondaryButton": "Voir les tarifs"
       },
       "howItWorks": {
         "label": "Comment ça marche",


### PR DESCRIPTION
## Summary
Complete German, French, and Spanish translations for the Onetime Secret website, including pricing features, error messages, use case descriptions, footer links, and marketing copy.

## Key Changes

### German (de.json)
- Updated pricing region label from "Zahlungsregion" to "Datenregion" (data region)
- Restructured Pro plan features list with clearer messaging
- Translated error messages: "Something went wrong" → "Etwas ist schiefgelaufen"
- Translated all use case titles and descriptions (IT & DevOps, Consultants, HR, Legal)
- Translated footer links and global infrastructure section
- Translated marketing copy: "Signed. Sealed. Delivered." → "Signiert. Versiegelt. Zugestellt."
- Translated feature labels and CTA buttons

### French (fr.json)
- Updated pricing region label from "Région de paiement" to "Région des données"
- Restructured Pro plan features with improved French phrasing
- Translated error messages and API error text
- Translated use case titles and descriptions with proper French terminology
- Translated footer and infrastructure sections
- Translated marketing tagline and CTA buttons
- Updated feature labels for consistency

### Spanish (es.json)
- Updated pricing region label from "Región de pago" to "Región de datos"
- Restructured Pro plan features with Spanish conventions
- Translated error messages: "Something went wrong" → "Algo salió mal"
- Translated use case titles and descriptions (IT y DevOps, Consultores y agencias, RR. HH., Legal y Finanzas)
- Translated footer links and infrastructure section
- Translated marketing copy and CTA buttons
- Updated feature labels for consistency

## Notable Details
- Consistent terminology across all three languages for data region/jurisdiction concepts
- Pro plan features reorganized to emphasize unlimited domains and member invitations
- All untranslated English strings in error messages and marketing sections now have proper translations
- Footer and infrastructure sections fully localized with region-specific translations

https://claude.ai/code/session_01YSh9dmrFUNUnZFxjVYZwdR