### PR TITLE
build: clear non-astro audit findings (shell-quote, yaml, esbuild ignore)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
       "mdast-util-to-hast": "^13.2.1",
       "@eslint/plugin-kit": "^0.3.4",
       "@modelcontextprotocol/sdk": "^1.29.0",
-      "@ungap/structured-clone": "^1.3.1"
+      "@ungap/structured-clone": "^1.3.1",
+      "shell-quote": "^1.8.4",
+      "yaml": "^2.8.3"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
       "@ungap/structured-clone": "^1.3.1",
       "shell-quote": "^1.8.4",
       "yaml": "^2.8.3"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-gv7w-rqvm-qjhr",
+        "GHSA-g7r4-m6w7-qqqr"
+      ]
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   '@eslint/plugin-kit': ^0.3.4
   '@modelcontextprotocol/sdk': ^1.29.0
   '@ungap/structured-clone': ^1.3.1
+  shell-quote: ^1.8.4
+  yaml: ^2.8.3
 
 importers:
 
@@ -4974,8 +4976,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
@@ -5485,7 +5487,7 @@ packages:
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5525,7 +5527,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5840,11 +5842,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -10331,7 +10328,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   levn@0.4.1:
     dependencies:
@@ -11647,7 +11644,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.23.0:
     dependencies:
@@ -12526,9 +12523,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

Clears the non-`astro` findings from `pnpm audit --audit-level=moderate` (the Security Audit CI job). Paired with #156 (Astro 6, which clears the `astro` advisories), this turns the audit gate green — verified locally: with both applied, `pnpm audit --audit-level=moderate` exits 0.

Only `package.json` (+ `pnpm-lock.yaml` for the overrides) changes.

## Changes

**Overrides** (deep, dev-time transitive deps; no runtime/build impact):

| Package | Sev | Fix | Path | Advisory |
|---|---|---|---|---|
| `shell-quote` | **critical** | `>=1.8.4` | `@spotlightjs/astro > launch-editor` | GHSA-w7jw-789q-3m8p |
| `yaml` | moderate | `>=2.8.3` | `@astrojs/check > yaml-language-server` | GHSA-48c2-rrv3-qjmp |

**Audit ignore** (`pnpm.auditConfig.ignoreGhsas`) for the **esbuild** advisories:

- `GHSA-gv7w-rqvm-qjhr` (high) and `GHSA-g7r4-m6w7-qqqr` (low)

esbuild's patched `0.28.1` can't be adopted yet — it drops destructuring down-leveling for our legacy browser targets and breaks the Vite build. Both advisories are dev/build-tool only (Deno `NPM_CONFIG_REGISTRY` RCE; Windows dev-server file read) and esbuild is not shipped to the browser in this SSG. The ignore is explicit and should be removed once vite/astro ship esbuild 0.28.

## Verification

- ✅ `pnpm install --frozen-lockfile` succeeds; `package.json` is valid
- ✅ `pnpm audit`: shell-quote (critical) and yaml gone; esbuild suppressed
- ✅ Combined with #156: `pnpm audit --audit-level=moderate` exits 0

## Note

This PR alone won't show a green Security Audit (the `astro` XSS remains until #156 lands), and #156 alone won't either (shell-quote/yaml/esbuild remain). **Both #155 and #156 must merge** for the gate to pass.

🤖 Generated with [Claude Code](https://claude.ai/code)