### PR TITLE
changelog: invites system now live in EU

### DIFF
--- a/src/content/changelog/2026-06-15-eu-invites-live.mdx
+++ b/src/content/changelog/2026-06-15-eu-invites-live.mdx
@@ -1,0 +1,17 @@
+---
+title: "Invites now live in EU"
+date: 2026-06-15
+description: "The invites system is now enabled in EU, completing the rollout across all five regions."
+category: news
+highlights:
+  - { icon: check, text: "European Union (EU)" }
+---
+
+The invites system is now up and running in EU (eu.onetimesecret.com), completing the rollout
+across all five regions. We held EU back by a day to let the feature soak in the other four
+regions first — EU carries roughly 10x the data of the next-largest region, so a short bake
+time is worth it. Everything looks good.
+
+Identity Plus accounts can invite unlimited members who can create and send secrets.
+
+[View Plans](/pricing)


### PR DESCRIPTION
## Summary

- Adds `2026-06-15-eu-invites-live.mdx` as a follow-up to the June 11 invite-members entry
- Announces that EU (eu.onetimesecret.com) now has the invites system enabled, completing the five-region rollout
- Category: `news`; ships immediately (no `planned: true`)

## Changelog entry preview

> **Invites now live in EU**
> The invites system is now up and running in EU (eu.onetimesecret.com), completing the rollout across all five regions. We held EU back by a day to let the feature soak in the other four regions first — EU carries roughly 10x the data of the next-largest region, so a short bake time is worth it. Everything looks good.
>
> Identity Plus accounts can invite unlimited members who can create and send secrets.

## Test plan

- [ ] Verify the entry appears on `/en/changelog` under the Shipped tab after build
- [ ] Verify the homepage banner updates to show this entry (dismissal key: `2026-06-15-eu-invites-live`)
- [ ] Confirm no TypeScript / Astro check errors

https://claude.ai/code/session_0192hmW3SjtpxovpP6ogYi1E

---
_Generated by [Claude Code](https://claude.ai/code/session_0192hmW3SjtpxovpP6ogYi1E)_